### PR TITLE
feat: adding release logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to create release from (usually main)'
+        required: true
+        default: 'main'
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for npm provenance
+    steps:
+      - name: checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+      - name: setup node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+        with:
+          node-version: "lts/*"
+      - name: release
+        uses: cycjimmy/semantic-release-action@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This will be 'true' for automated pushes to main, 'false' for manual workflow runs
+          IS_PRERELEASE: ${{ github.event_name == 'push' }}

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,9 @@
+plugins:
+  - "@semantic-release/github"
+  - "@semantic-release/commit-analyzer"
+  - "@semantic-release/release-notes-generator"
+  - "@semantic-release/changelog"
+  - "@semantic-release/git"
+branches:
+  - name: main
+    prerelease: ${process.env.IS_PRERELEASE === 'true' ? 'next' : false}

--- a/.releaserc
+++ b/.releaserc
@@ -6,4 +6,4 @@ plugins:
   - "@semantic-release/git"
 branches:
   - name: main
-    prerelease: ${process.env.IS_PRERELEASE === 'true' ? 'next' : false}
+    prerelease: ${process.env.IS_PRERELEASE === 'true' ? 'rc' : false}


### PR DESCRIPTION
## Description
This PR adds semantic release functionality to the repository. It implements automatic pre-releases on merges to the `main` branch and allows the manual creation of full releases via a GitHub workflow.

## Motivation and Context
Currently, the repository lacks automated release management. This change will:
- Automate version numbering based on conventional commits
- Create pre-releases automatically when code is merged to main
- Allow engineers to create full releases manually when needed
- Generate changelogs automatically

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/swade1987/flux2-kustomize-template/blob/main/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
