### PR TITLE
ci: bring repo up to standard, update stale toolkit/action versions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Names the repo owner for GitHub's own UI (review requests, blame).
+# The branch ruleset does not require owner review before merge - this
+# file's effect is currently informational only.
+* @swade1987

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"

--- a/.github/workflows/commit-lint.yaml
+++ b/.github/workflows/commit-lint.yaml
@@ -1,7 +1,7 @@
 name: commit-lint
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
@@ -14,7 +14,15 @@ permissions:
 jobs:
   commit-lint:
     name: commit-lint
+    # Dependabot's own commit messages don't pass commitlint's stricter
+    # subject-case rules (its PR titles do - pr-lint still runs for these).
+    # Keyed on the PR's actual author, not github.actor - a manual "update
+    # branch" would otherwise flip actor away from dependabot[bot] and make
+    # this job run for real on a Dependabot commit it was meant to exempt.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: wagoid/commitlint-github-action@3d28780bbf0365e29b144e272b2121204d5be5f3 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1

--- a/.github/workflows/kustomize-checks.yaml
+++ b/.github/workflows/kustomize-checks.yaml
@@ -9,10 +9,10 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    container: eu.gcr.io/swade1987/kubernetes-toolkit:1.26.0
+    container: eu.gcr.io/swade1987/kubernetes-toolkit:1.43.0
     steps:
       - name: clone repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: duplicate-helmrelease-name-check
         run: make duplicate-release-name-check
 
@@ -20,10 +20,10 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    container: eu.gcr.io/swade1987/kubernetes-toolkit:1.26.0
+    container: eu.gcr.io/swade1987/kubernetes-toolkit:1.43.0
     steps:
       - name: clone repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: kubeconform-checks
@@ -33,9 +33,9 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    container: eu.gcr.io/swade1987/kubernetes-toolkit:1.26.0
+    container: eu.gcr.io/swade1987/kubernetes-toolkit:1.43.0
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: pluto-checks
@@ -45,10 +45,10 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    container: eu.gcr.io/swade1987/kubernetes-toolkit:1.26.0
+    container: eu.gcr.io/swade1987/kubernetes-toolkit:1.43.0
     steps:
       - name: clone repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: istioctl-checks
         run: make istio-checks
 
@@ -56,10 +56,10 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    container: eu.gcr.io/swade1987/kubernetes-toolkit:1.26.0
+    container: eu.gcr.io/swade1987/kubernetes-toolkit:1.43.0
     steps:
       - name: clone repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Git Safe Directory
         run: git config --global --add safe.directory '*'
       - name: kustomize lint
@@ -70,19 +70,19 @@ jobs:
   kustomize-diff:
     permissions:
       pull-requests: write
-      contents: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - id: kustomize-diff
-        uses: swade1987/github-action-kustomize-diff@v0.5.0
+        uses: swade1987/github-action-kustomize-diff@v0.6.0
         with:
           root_dir: "./kustomize"
           max_depth: "2"
       - id: comment
-        uses: actions/github-script@v7.0.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           OUTPUT: ${{ steps.kustomize-diff.outputs.diff }}
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: lint
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
+        with:
+          severity: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,16 +16,16 @@ jobs:
       id-token: write # to enable use of OIDC for npm provenance
     steps:
       - name: checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
           token: ${{ secrets.RELEASE_TOKEN }}
       - name: setup node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "lts/*"
       - name: release
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@16ca923e6ccbb50770c415a0ccd43709a8c5f7a4 # v4.2.2
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,42 @@
+name: Scorecard analysis workflow
+on:
+  push:
+    branches:
+    - main
+  schedule:
+    - cron:  '30 1 * * 6'
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/semantic-lint.yml
+++ b/.github/workflows/semantic-lint.yml
@@ -1,7 +1,7 @@
 name: pr-lint
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
@@ -16,6 +16,6 @@ jobs:
     name: pr-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GOOS          ?= $(if $(TARGETOS),$(TARGETOS),linux)
 GOARCH        ?= $(if $(TARGETARCH),$(TARGETARCH),amd64)
 BUILDPLATFORM ?= $(GOOS)/$(GOARCH)
 
-TOOLKIT_IMAGE := eu.gcr.io/swade1987/kubernetes-toolkit:1.26.0
+TOOLKIT_IMAGE := eu.gcr.io/swade1987/kubernetes-toolkit:1.43.0
 KUSTOMIZE_VERSION := v5.8.1
 
 # ############################################################################################################

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![kustomize-checks](https://github.com/swade1987/flux2-kustomize-template/actions/workflows/kustomize-checks.yaml/badge.svg)](https://github.com/swade1987/flux2-kustomize-template/actions/workflows/kustomize-checks.yaml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/swade1987/flux2-kustomize-template/badge)](https://scorecard.dev/viewer/?uri=github.com/swade1987/flux2-kustomize-template)
 
 # Flux Kustomize Template
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Supported versions
+
+This template ships one rolling `latest` semantic-release version; there's no long-term-support branch to track. Fixes land on `main` and are published as the next tagged release.
+
+## Reporting a vulnerability
+
+Please report security issues privately rather than opening a public GitHub issue: use [GitHub's private vulnerability reporting](https://github.com/swade1987/flux2-kustomize-template/security/advisories/new) for this repository (Security tab → Report a vulnerability).
+
+Include what you'd include in any good bug report: the affected version or commit, what you found, and how to reproduce it. We'll acknowledge new reports within 5 business days and aim to have a fix or mitigation plan within 30 days, depending on severity.
+
+## Scope
+
+This is a GitOps repository template - the CI checks (kubeconform, pluto, istio-checks, duplicate-release-name-checks, kustomize-diff) and the scripts under `bin/` are in scope. The example Kubernetes manifests under `kustomize/` are illustrative content, not a security boundary.


### PR DESCRIPTION
(This post authored by my [AgenC](https://github.com/mieubrisse/agenc))

## Summary

- `commit-lint.yaml` and `semantic-lint.yml` both used `pull_request_target` - the same dangerous-workflow pattern already fixed on the sibling repos.
- `container: eu.gcr.io/swade1987/kubernetes-toolkit:1.26.0` was duplicated across five jobs, badly stale - bumped to `1.43.0`, the current real published tag (verified it actually pulls before using it, not just inferred from a version number). Same fix in the Makefile's `TOOLKIT_IMAGE` variable, used for the equivalent local `make local-*` targets.
- `swade1987/github-action-kustomize-diff@v0.5.0` bumped to `v0.6.0` (released a few hours ago, from the PR that just landed on that repo).
- The `kustomize-diff` job requested `contents: write` for a step that never pushes anything - same over-permissioned pattern already fixed in that action's own README, now fixed here too (`contents: read`).
- Pinned/refreshed the remaining stale action SHAs (`actions/checkout`, `actions/github-script`, `actions/setup-node`, `cycjimmy/semantic-release-action`).

Also added, matching the established bar on the sibling repos: shellcheck (verified clean on the existing `bin/*.sh` scripts before requiring it), Scorecard, Dependabot, SECURITY.md, CODEOWNERS.

**On Dependabot and the toolkit image specifically**: Dependabot's `docker` ecosystem is documented as scanning Dockerfiles and docker-compose files; I could not find clear documentation confirming it also scans a `container:` field inside a GitHub Actions workflow YAML file, which is the only place this repo references the toolkit image (there's no Dockerfile here). I've configured it as if it does (`docker` ecosystem, `directory: "/"`), since that's the only way to point it at this reference at all - but this is genuinely unverified rather than confirmed, and I'll know for sure once Dependabot's first scan either does or doesn't produce a PR for it.

## Test plan
- [x] Verified `eu.gcr.io/swade1987/kubernetes-toolkit:1.43.0` is a real, currently-pullable tag before referencing it
- [x] `shellcheck --severity=error` on all of `bin/*.sh` and `bin/scale-apps-in-env` - clean, before adding the workflow that requires it
- [x] All workflow YAML parses (`yq eval`)