### PR TITLE
fix: resolve two real OpenSSF Scorecard findings

### DIFF
--- a/.github/workflows/kustomize-checks.yaml
+++ b/.github/workflows/kustomize-checks.yaml
@@ -3,6 +3,11 @@ name: kustomize-checks
 on:
   pull_request:
 
+# Safe floor for any job that doesn't declare its own permissions; every
+# job below already declares its own anyway.
+permissions:
+  contents: read
+
 jobs:
 
   duplicate-release-name-checks:
@@ -77,7 +82,7 @@ jobs:
         with:
           fetch-depth: 0
       - id: kustomize-diff
-        uses: swade1987/github-action-kustomize-diff@v0.6.0
+        uses: swade1987/github-action-kustomize-diff@f9d6df0d7d6b907eced57dbbf15791ec3a08800f # v0.6.0
         with:
           root_dir: "./kustomize"
           max_depth: "2"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+# Safe floor for any job that doesn't declare its own permissions; the
+# release job below still needs and declares its own broader grants.
+permissions:
+  contents: read
+
 jobs:
   release:
     name: release


### PR DESCRIPTION
(This post authored by my [AgenC](https://github.com/mieubrisse/agenc))

## Summary

Pulled the actual SARIF findings from the first real Scorecard run rather than guessing at what to fix.

- **Pinned-Dependencies (8/10)**: `swade1987/github-action-kustomize-diff@v0.6.0` was pinned by tag, not SHA - missed this one because it's a first-party action and I didn't apply the same rigor as I did to third-party ones elsewhere. Pinned to its real commit SHA.
- **Token-Permissions (9/10)**: `release.yml` and `kustomize-checks.yaml` both lacked a workflow-level `permissions:` floor. Every job in both files already declares its own explicit permissions, so this was already secure in practice - Scorecard still flags the missing floor regardless, matching the pattern already used on every sibling repo.

## Not fixed, deliberately

- **Code-Review (0) / Branch-Protection (4)**: same tradeoff already made on podium/kubernetes-toolkit - this repo has one contributor, so a required-review rule wouldn't catch anything a solo author wasn't going to merge anyway; it would just recreate the self-approval deadlock already worked through on the other repos.
- **SAST (0)**: checked what Scorecard actually recognizes - CodeQL supports specific application languages (JS/TS, Python, Java, C/C++, C#, Go, Ruby, Swift), none of which this repo has. It's YAML manifests and shell scripts, already covered by shellcheck/kubeconform/pluto/istio-checks - none of which Scorecard's SAST check recognizes as a SAST tool. Adding CodeQL here would scan nothing real.
- **Packaging (-1) / Fuzzing (0) / Contributors (3) / CII-Best-Practices (0)**: not applicable to a GitOps config template, or need a manual account signup outside what I can automate - same as the other repos.

## Test plan
- [x] Resolved `github-action-kustomize-diff@v0.6.0`'s real commit SHA via the GitHub API, not guessed
- [x] Workflow YAML parses (`yq eval`)