### PR TITLE
chore: remove OpenSSF Scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![kustomize-checks](https://github.com/swade1987/flux2-kustomize-template/actions/workflows/kustomize-checks.yaml/badge.svg)](https://github.com/swade1987/flux2-kustomize-template/actions/workflows/kustomize-checks.yaml)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/swade1987/flux2-kustomize-template/badge)](https://scorecard.dev/viewer/?uri=github.com/swade1987/flux2-kustomize-template)
 
 # Flux Kustomize Template
 


### PR DESCRIPTION
(This post authored by my [AgenC](https://github.com/mieubrisse/agenc))

## Summary
- The Scorecard badge renders as "invalid repo path" for this repo. Verified the underlying `api.scorecard.dev` data is genuinely fine (real score, full check breakdown when queried directly) - the failure is specific to shields.io's badge-rendering integration, which appears to mishandle GitHub repos with `is_template: true` set (confirmed by comparing against non-template sibling repos, whose badges render correctly). Since `is_template` is what makes this repo's "Use this template" button work, that isn't something to change to work around a third-party rendering bug.
- A visibly broken badge is worse than no badge, especially on a repo people are pointed at during training - removing it until upstream fixes this.

## Test plan
- [x] Confirmed via direct badge SVG inspection that this is a shields.io rendering issue, not a data issue on scorecard.dev's side